### PR TITLE
fix: loading bar `status` change should trigger cd

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -244,7 +244,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "rajansolanki.dev/loading-bar@1.0.0": {
+    "rajansolanki.dev/loading-bar@1.0.3": {
         "files": [
             {
                 "relativePath": "src/app/components/loading-bar/components/loading-bar.component.html",

--- a/src/app/components/loading-bar/components/loading-bar.component.ts
+++ b/src/app/components/loading-bar/components/loading-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 export type Status = 'loading' | 'error' | 'idle';
 
@@ -6,7 +6,6 @@ export type Status = 'loading' | 'error' | 'idle';
   selector: 'component-loading-bar',
   templateUrl: './loading-bar.component.html',
   styleUrls: ['./loading-bar.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LoadingBarComponent {
   @Input() status: Status = 'idle';


### PR DESCRIPTION
Previously, `LoadingBarComponent` used on push change detection. Changing its `status` input outside of an angular app didnt trigger cd, so this commit changes the component to use default cd