### PR TITLE
feat: make `ErrorComponent` displayed error type controllable

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -113,7 +113,7 @@
         "origin": "AUTHORED",
         "exported": true
     },
-    "rajansolanki.dev/error@1.0.1": {
+    "rajansolanki.dev/error@2.0.1": {
         "files": [
             {
                 "relativePath": "src/app/components/error/components/error.animations.ts",

--- a/src/app/components/error/components/error.component.html
+++ b/src/app/components/error/components/error.component.html
@@ -1,15 +1,15 @@
 <div
   id="banner-global"
   class="banner"
-  *ngIf="!showAppError"
+  *ngIf="type === 'global'"
   role="alertdialog"
   aria-labelledby="banner-global-error"
 >
   <div class="banner-container" tabindex="0">
     <p id="banner-global-error">Oops, an error occurred</p>
     <div class="banner-actions">
-      <a id="banner-global-action-home">Back to products</a>
-      <a id="banner-global-action-reload">Reload</a>
+      <a>Back to products</a>
+      <a>Reload</a>
     </div>
   </div>
 </div>
@@ -17,7 +17,7 @@
 <div
   id="banner-app"
   class="banner"
-  *ngIf="showAppError"
+  *ngIf="type === 'app'"
   @enterLeave
   role="alertdialog"
   aria-labelledby="banner-app-error"
@@ -25,12 +25,12 @@
   <div class="banner-container" tabindex="0">
     <p id="banner-app-error">Couldn&rsquo;t load products</p>
     <div class="banner-actions">
-      <button (click)="handleAppClick()">
+      <a>
         Dismiss
-      </button>
-      <button (click)="handleAppClick()">
+      </a>
+      <a>
         Retry
-      </button>
+      </a>
     </div>
   </div>
 </div>

--- a/src/app/components/error/components/error.component.scss
+++ b/src/app/components/error/components/error.component.scss
@@ -1,11 +1,6 @@
 @import 'src/app/components/sass/reset', 'src/app/components/sass/mixins';
 
-button {
-  @extend %button;
-}
-
-a,
-button {
+a {
   @include hoverScale(1.1, 0.9);
 }
 
@@ -39,8 +34,7 @@ button {
       display: flex;
       margin: 0.25em (-$button-padding);
 
-      a,
-      button {
+      a {
         display: block;
         margin: $button-padding;
         padding: $button-padding;
@@ -56,8 +50,7 @@ button {
   animation: reveal 0.4s cubic-bezier(0.86, 0, 0.07, 1) forwards;
 
   .banner-actions {
-    a,
-    button {
+    a {
       @include innerButtonBackground($red-primary);
       color: $white-text-primary;
     }
@@ -69,8 +62,7 @@ button {
   color: $red-secondary-text;
 
   .banner-actions {
-    a,
-    button {
+    a {
       @include innerButtonBackground($red-secondary);
       color: $red-secondary-text;
     }

--- a/src/app/components/error/components/error.component.ts
+++ b/src/app/components/error/components/error.component.ts
@@ -1,18 +1,15 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { errorAnimations } from './error.animations';
+
+export type ErrorType = 'app' | 'global';
 
 @Component({
   selector: 'component-error',
   templateUrl: './error.component.html',
   styleUrls: ['./error.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: errorAnimations,
 })
 export class ErrorComponent {
-  showAppError = true;
-
-  handleAppClick(): void {
-    this.showAppError = false;
-  }
+  @Input() type: ErrorType | undefined;
 }

--- a/src/app/components/error/index.ts
+++ b/src/app/components/error/index.ts
@@ -1,10 +1,10 @@
 import { NgElement, WithProperties } from '@angular/elements';
 
-import { ErrorComponent } from './components/error.component';
+import { ErrorComponent, ErrorType } from './components/error.component';
 import { ErrorModule, NAME } from './error.module';
 import { setup } from './setup';
 
-type ComponentProps = WithProperties<Pick<ErrorComponent, never>>;
+type ComponentProps = WithProperties<Pick<ErrorComponent, 'type'>>;
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -18,4 +18,4 @@ declare global {
   }
 }
 
-export { setup as default, ErrorModule };
+export { setup as default, ErrorModule, ErrorType };

--- a/src/app/routes/error/error.component.spec.ts
+++ b/src/app/routes/error/error.component.spec.ts
@@ -27,6 +27,10 @@ describe('`ErrorComponent`', () => {
     it('should display web component', () => {
       expect(page.component).toBeTruthy();
     });
+
+    it('should set `type`', () => {
+      expect(page.component.getAttribute('type')).toBe('app');
+    });
   });
 });
 

--- a/src/app/routes/error/error.component.ts
+++ b/src/app/routes/error/error.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-error',
-  template: `<component-error></component-error>`,
+  template: `<component-error type="app"></component-error>`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ErrorComponent {}


### PR DESCRIPTION
Previously `ErrorComponent` would first show an app error, then a global error on button click. This commit makes it so that `ErrorComponent` can be passed a type of error to display instead

BREAKING CHANGE: `ErrorComponent` now requires a `type` input, of either 'app' or 'global'