### PR TITLE
ci: update cypress docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cypress/base:13.6.0
+      - image: cypress/base:13.8.0
         environment:
           TERM: xterm
     steps:


### PR DESCRIPTION
PR #65 was failing because `cypress/base:13.6.0` was missing a dependency